### PR TITLE
Source Han Serif SC, Noto Sans CJK SC, Noto Serif CJK SC

### DIFF
--- a/src/fonts.yml
+++ b/src/fonts.yml
@@ -22,10 +22,17 @@
   platform: Mac
 
 - 
+  name: Noto Sans CJK
+  alias:
+    - Noto Sans CJK SC
+  family: 黑体
+  platform: Linux
+
+- 
   name: 思源黑体
   alias:
-    - Source Han Sans CN
     - Source Han Sans SC
+    - Source Han Sans CN
   family: 黑体
   platform: Adobe
 
@@ -104,6 +111,21 @@
   platform:
     - Windows[MS Office]
     - Mac
+ 
+ - 
+  name: Noto Serif CJK
+  alias:
+    - Noto Serif CJK SC
+  family: 宋体
+  platform: Linux
+
+- 
+  name: 思源宋体
+  alias:
+    - Source Han Serif SC
+    - Source Han Serif CN
+  family: 宋体
+  platform: Adobe
 
 -
   name: AR PL New Sung


### PR DESCRIPTION
1. 添加了新发布的思源宋体。
2. Google 打包了思源黑体和宋体，并且用 Noto 这个名字发布出来，所以在这里一并添加。Android 会全面内置 Noto 字体族，并且 Ubuntu / Fedora 已经把 Noto Sans CJK 标记为默认中文字体，所以在列表中我把它们和 Adobe 的分开来写了，而且平台记为 Linux。
3. 只修改了 yml 文件。